### PR TITLE
Remove useless friend declaration in AABB

### DIFF
--- a/include/LTBL/Constructs/AABB.h
+++ b/include/LTBL/Constructs/AABB.h
@@ -50,8 +50,6 @@ public:
 
 	// Render the AABB for debugging purposes
 	void DebugRender();
-
-	friend class AABB;
 };
 
 #endif


### PR DESCRIPTION
Remove useless friend declaration in AABB as AABB class can already access another AABB class private attributes.